### PR TITLE
Adding flask-script and commands for setting up cron and running a scan 

### DIFF
--- a/app/manage.py
+++ b/app/manage.py
@@ -1,0 +1,37 @@
+
+from crontab import CronTab
+
+from flask.ext.script import Manager
+from flask.ext.script import Server
+
+from main import app
+
+manager = Manager(app)
+manager.add_command("runserver", Server(host='0.0.0.0', port=5000))
+
+#TODO: This probably needs to be a setting somewhere. Most likely kept in the database.
+VINZ_USER = 'vagrant'
+VINZ_COMMENT = 'vinz'
+SCAN_COMMAND = '/usr/bin/python /vagrant/app/manage.py scan'
+
+
+@manager.command
+def setup_cron():
+    """
+    Sets up a cron job in the user's crontab in order to run the scan every minute.
+    """
+    cron = CronTab(user=VINZ_USER)
+    num_jobs = sum(1 for _ in cron.find_comment(VINZ_COMMENT))
+    if not num_jobs:
+        job = cron.new(command=SCAN_COMMAND, comment=VINZ_COMMENT)
+        job.minute.every(1)
+        job.enable()
+        cron.write()
+
+
+@manager.command
+def scan():
+    pass
+
+if __name__ == "__main__":
+    manager.run()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -16,3 +16,5 @@ pycrypto==2.6
 pymongo==2.6.3
 six==1.4.1
 wsgiref==0.1.2
+python-crontab==1.7.0
+Flask-Script==0.6.6


### PR DESCRIPTION
This adds flask-script, which makes it easy for us to setup commands for the server to do different things. 

I added one for setting up a cron job, as well as a stub for running an individual scan.  

To setup the cron job, run `python manage.py setup_cron` on the vagrant server.

Review:
@organman91
